### PR TITLE
Change search results card CSS

### DIFF
--- a/src/viewer/web/qs/style.css
+++ b/src/viewer/web/qs/style.css
@@ -1298,7 +1298,12 @@ a.card .card-excerpt {
 }
 a.card:hover .card-excerpt {
 	color:#333
+
 }
+a.card:hover {
+	text-decoration: none;
+}
+
 .card-source {
 	font-style:italic;
 	margin-top:1.5rem;


### PR DESCRIPTION
CSS was changed to overwrite card hover highlight inherited from
NICE bootstrap CSS.